### PR TITLE
Change log level to ERROR when request failed async

### DIFF
--- a/gdbclient/gdbclient.go
+++ b/gdbclient/gdbclient.go
@@ -221,7 +221,7 @@ func (c *baseClient) transaction(ops string) error {
 func (c *baseClient) requestAsync(request *graphsonv3.Request) (*graphsonv3.ResponseFuture, error) {
 	conn, err := c.connPool.Get()
 	if err != nil {
-		internal.Logger.Info("request connect failed",
+		internal.Logger.Error("request connect failed",
 			zap.Time("time", time.Now()),
 			zap.Error(err))
 		return nil, err
@@ -240,7 +240,7 @@ func (c *baseClient) requestAsync(request *graphsonv3.Request) (*graphsonv3.Resp
 	if err != nil {
 		// return connection to pool if request is not pending
 		c.connPool.Put(conn)
-		internal.Logger.Info("submit script failed",
+		internal.Logger.Error("submit script failed",
 			zap.Time("time", time.Now()),
 			zap.Uintptr("conn", uintptr(unsafe.Pointer(conn))),
 			zap.Error(err),


### PR DESCRIPTION
There are too many info logs when send large number of requests, there is no way to filter out failed requests by custom logger at this point.